### PR TITLE
Show weekly schedule when clicking room cards

### DIFF
--- a/frontend/style.css
+++ b/frontend/style.css
@@ -235,7 +235,7 @@ header p {
 .modal-content {
     background: white;
     border-radius: 10px;
-    max-width: 600px;
+    max-width: 900px;
     width: 90%;
     max-height: 80vh;
     overflow-y: auto;
@@ -276,6 +276,54 @@ header p {
 
 .modal-body {
     padding: 20px;
+}
+
+.weekly-schedule {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 20px;
+}
+
+.day-column {
+    background: #ffffff;
+    border: 1px solid #e2e8f0;
+    border-radius: 10px;
+    display: flex;
+    flex-direction: column;
+    min-height: 180px;
+    overflow: hidden;
+}
+
+.day-header {
+    background: #eff6ff;
+    border-bottom: 1px solid #e2e8f0;
+    padding: 14px 16px;
+}
+
+.day-name {
+    display: block;
+    font-weight: 700;
+    color: #1e3a8a;
+    margin-bottom: 4px;
+}
+
+.day-date {
+    color: #475569;
+    font-size: 0.9em;
+}
+
+.day-body {
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    flex: 1;
+}
+
+.day-empty {
+    text-align: center;
+    color: #94a3b8;
+    font-style: italic;
 }
 
 .schedule-list {
@@ -357,5 +405,14 @@ header p {
 
     .modal-body {
         padding: 15px;
+    }
+
+    .weekly-schedule {
+        grid-template-columns: 1fr;
+        gap: 15px;
+    }
+
+    .day-body {
+        padding: 14px;
     }
 }


### PR DESCRIPTION
## Summary
- ensure room result cards expose valid data attributes so the click handler can read room metadata
- replace the daily schedule popup with a weekly view and add helpers to build the week data
- style the modal for the new weekly layout and widen the dialog for readability

## Testing
- not run (frontend project without automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68ce7eae77b4832a9d1094fdc8c3cde5